### PR TITLE
投稿一覧のログインの有無に応じた設定、詳細ページの記載

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,6 @@
 class PrototypesController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+  
   def index
     @prototypes = Prototype.all
   end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image.variant(resize: '500x500'), class: 'card__img'), root_path if prototype.image.attached? %>
+  <%= link_to image_tag(prototype.image.variant(resize: '500x500'), class: 'card__img'), prototype_path(prototype) if prototype.image.attached? %>
   <div class="card__body">
-    <%= link_to prototype.title, root_path, class: 'card__title' %>
+    <%= link_to prototype.title, prototype_path(prototype), class: 'card__title' %>
 
     <p class="card__summary">
       <%= prototype.catch_copy %>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -2,8 +2,11 @@
   <div class="inner">
       <div class="greeting"> 
         こんにちは、
-        <%= link_to "ユーザー名さん", root_path, class: :greeting__link%>
-      </div>
+      <% if user_signed_in? %>
+        <%= link_to "#{current_user.name} さん", root_path, class: :greeting__link %>
+      <% else %>
+        ゲストさん
+      <% end %>
   <div class="card__wrapper">
     <% @prototypes.each do |prototype| %>
       <%= render partial: "prototype", locals: {prototype: prototype} %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,34 +2,36 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.title %>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <% if current_user == @prototype.user %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      <% end %>
       <div class="prototype__image">
-        <%= image_tag "プロトタイプの画像" %>
+        <%= image_tag (@prototype.image) %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= "プロトタイプのキャッチコピー" %>
+            <%= @prototype.catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= "プロトタイプのコンセプト" %>
+            <%= @prototype.concept %>
           </p>
         </div>
       </div>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
+        <%#  <% if user_signed_in? %>
+        <%#  <%= form_with model: [@prototype, @prototype.comments.build],local: true do |f|%>
             <div class="field">
               <%# <%= f.label :hoge, "コメント" %><br />
               <%# <%= f.text_field :hoge, id:"comment_content" %>
@@ -37,13 +39,13 @@
             <div class="actions">
               <%# <%= f.submit "送信する", class: :form__btn  %>
             </div>
-          <%# <% end %>
+          <%#<% end %>
         <%# // ログインしているユーザーには上記を表示する %>
         <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
             <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+              <%= " コメントのテキスト "%>
+              <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
             </li>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>


### PR DESCRIPTION
# What
プロトタイプ詳細機能の設定

# Why
プロトタイプ詳細機能設定のため。
一覧機能時、ログイン名がユーザー名のままになっていたため、
ログイン時はログインネームに、未ログイン時はゲストに合わせて修正

Gyazo
＜ログイン時＞
https://gyazo.com/8068a0c4269ffd1187a9cac8b763a43d

＜未ログイン時＞
https://gyazo.com/832a8d73b52dcc487b7180a5386190a9
