### PR TITLE
プロトタイプ編集機能２

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,8 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  
+  before_action :set_prototype, only: [:edit, :update, :show]
+
+
   def index
     @prototypes = Prototype.all
   end
@@ -19,15 +21,15 @@ class PrototypesController < ApplicationController
   end
 
   def show
-    @prototype = Prototype.find(params[:id])
   end
 
   def edit
-    @prototype = Prototype.find(params[:id])
+    if current_user != @prototype.user
+      redirect_to root_path
+    end
   end
 
   def update
-    @prototype = Prototype.find(params[:id])
     if @prototype.update(prototype_params)
       redirect_to @prototype
     else
@@ -38,6 +40,10 @@ class PrototypesController < ApplicationController
 private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+  end
+
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
   end
 end
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -22,6 +22,19 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
+  def edit
+    @prototype = Prototype.find(params[:id])
+  end
+
+  def update
+    @prototype = Prototype.find(params[:id])
+    if @prototype.update(prototype_params)
+      redirect_to @prototype
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
 private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -3,6 +3,7 @@
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
       <%# 部分テンプレートでフォームを表示する %>
+      <%= render partial: "form", locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
       <% if current_user == @prototype.user %>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: "prototypes#index"
   devise_for :users
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
プロトタイプ投稿編集機能の実装

# Why
プロトタイプ投稿編集機能の実装のため

- ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画 https://gyazo.com/909e72d4978fb38769ec0b7f9b2677fd 
- 必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
https://gyazo.com/c480d8f0392ed9629b4cc1939f792335

- 入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/e51f8b0d233c6fe62ebf8a7390e25a61

- 何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
https://gyazo.com/d9b09d6e18e91489abf8c8f3dd654507

- ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/6403990d9741bcc983493b742c202d57

- ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/b0ab37e180fdbba14949997a11e739ca

- プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
https://gyazo.com/af357d681709546f2e5f161bb7feb6aa
