### PR TITLE
プロトタイプ削除機能の実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -20,6 +20,10 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
+  def destory
+
+  end
+
 private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -22,9 +22,9 @@ class PrototypesController < ApplicationController
     @prototype = Prototype.find(params[:id])
   end
 
-  def destory
-    prototype = Prototype.find(params[:id])
-    prototype.destory
+  def destroy
+    prototypes = Prototype.find(params[:id])
+    prototypes.destroy
     redirect_to root_path
   end
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -21,7 +21,9 @@ class PrototypesController < ApplicationController
   end
 
   def destory
-
+    prototype = Prototype.find(params[:id])
+    prototype.destory
+    redirect_to root_path
   end
 
 private

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", user_registration_path, class: :prototype__btn %>
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
       <% if current_user == @prototype.user %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", prototype_path(prototype.id),data:{ turbo_method: :delete} ,class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id),data:{ turbo_method: :delete } ,class: :prototype__btn %>
         </div>
       <% end %>
       <div class="prototype__image">

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", user_registration_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(prototype.id),data:{ turbo_method: :delete} ,class: :prototype__btn %>
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: "prototypes#index"
   devise_for :users
-  resources :prototypes, only: [:index, :new, :create, :show, :destory]
+  resources :prototypes, only: [:index, :new, :create, :show, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: "prototypes#index"
   devise_for :users
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show, :destory]
 end


### PR DESCRIPTION
# WHAT
プロトタイプ削除機能の実装
# WHY
削除機能の実装のため


ログイン状態の投稿者のみ、詳細ページの削除ボタンを押すと、投稿したプロトタイプを削除できる動画
https://i.gyazo.com/8f14ed25a156fc2b6291a1b3c79684df.gif

